### PR TITLE
Feature binary serial

### DIFF
--- a/MyGameMaker/MyAnimationEngine/SkeletalAnimationComponent.cpp
+++ b/MyGameMaker/MyAnimationEngine/SkeletalAnimationComponent.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <MyScriptingEngine/MonoManager.h>
 #include <mono/metadata/debug-helpers.h>
+#include <fstream>
 
 SkeletalAnimationComponent::SkeletalAnimationComponent(GameObject* owner) : Component(owner)
 {
@@ -108,4 +109,280 @@ MonoObject* SkeletalAnimationComponent::GetSharp()
     mono_runtime_invoke(method, monoObject, args, NULL);
     CsharpReference = monoObject;
     return CsharpReference;
+}
+
+void SkeletalAnimationComponent::SaveBinary(const std::string& filename) const
+{
+	std::string fullPath = "Library/Animation/" + filename + ".anim";
+
+	if (!std::filesystem::exists("Library/Animation")) {
+		std::filesystem::create_directory("Library/Animation");
+	}
+
+	std::ofstream fout(fullPath, std::ios::binary);
+	if (!fout.is_open()) {
+		LOG(LogType::LOG_ERROR, "Error al guardar la animación esqueletal: %s", fullPath.c_str());
+		return;
+	}
+
+	fout.write(reinterpret_cast<const char*>(&isPlaying), sizeof(isPlaying));
+	fout.write(reinterpret_cast<const char*>(&animationIndex), sizeof(animationIndex));
+
+	uint32_t numAnimations = static_cast<uint32_t>(animations.size());
+	fout.write(reinterpret_cast<const char*>(&numAnimations), sizeof(numAnimations));
+
+	for (const auto& animation : animations) {
+		if (animation) {
+			uint32_t nameLength = static_cast<uint32_t>(animation->GetName().length());
+			fout.write(reinterpret_cast<const char*>(&nameLength), sizeof(nameLength));
+			fout.write(animation->GetName().c_str(), nameLength);
+
+			float duration = animation->GetDuration2();
+			int ticksPerSecond = animation->GetTicksPerSecond2();
+			fout.write(reinterpret_cast<const char*>(&duration), sizeof(duration));
+			fout.write(reinterpret_cast<const char*>(&ticksPerSecond), sizeof(ticksPerSecond));
+
+			const auto& animNames = animation->GetAnimations();
+			uint32_t numAnimNames = static_cast<uint32_t>(animNames.size());
+			fout.write(reinterpret_cast<const char*>(&numAnimNames), sizeof(numAnimNames));
+			for (const auto& name : animNames) {
+				uint32_t animNameLength = static_cast<uint32_t>(name.length());
+				fout.write(reinterpret_cast<const char*>(&animNameLength), sizeof(animNameLength));
+				fout.write(name.c_str(), animNameLength);
+			}
+
+			const auto& boneMap = animation->GetBoneIDMap();
+			uint32_t numBones = static_cast<uint32_t>(boneMap.size());
+			fout.write(reinterpret_cast<const char*>(&numBones), sizeof(numBones));
+
+			for (const auto& [boneName, boneInfo] : boneMap) {
+				uint32_t boneNameLength = static_cast<uint32_t>(boneName.length());
+				fout.write(reinterpret_cast<const char*>(&boneNameLength), sizeof(boneNameLength));
+				fout.write(boneName.c_str(), boneNameLength);
+
+				fout.write(reinterpret_cast<const char*>(&boneInfo.id), sizeof(boneInfo.id));
+
+				fout.write(reinterpret_cast<const char*>(&boneInfo.offset), sizeof(glm::mat4));
+			}
+
+			uint32_t numBonesList = static_cast<uint32_t>(animation->m_Bones.size());
+			fout.write(reinterpret_cast<const char*>(&numBonesList), sizeof(numBonesList));
+
+			for (auto& bone : animation->m_Bones) {
+				uint32_t boneNameLength = static_cast<uint32_t>(bone.GetBoneName().length());
+				fout.write(reinterpret_cast<const char*>(&boneNameLength), sizeof(boneNameLength));
+				fout.write(bone.GetBoneName().c_str(), boneNameLength);
+
+				uint32_t parentNameLength = static_cast<uint32_t>(bone.GetParentName().length());
+				fout.write(reinterpret_cast<const char*>(&parentNameLength), sizeof(parentNameLength));
+				fout.write(bone.GetParentName().c_str(), parentNameLength);
+
+				int boneID = bone.GetBoneID();
+				fout.write(reinterpret_cast<const char*>(&boneID), sizeof(boneID));
+
+				const auto& positions = bone.m_Positions;
+				uint32_t numPositions = static_cast<uint32_t>(positions.size());
+				fout.write(reinterpret_cast<const char*>(&numPositions), sizeof(numPositions));
+				for (const auto& pos : positions) {
+					fout.write(reinterpret_cast<const char*>(&pos.timeStamp), sizeof(float));
+					fout.write(reinterpret_cast<const char*>(&pos.position), sizeof(glm::vec3));
+				}
+
+				const auto& rotations = bone.m_Rotations;
+				uint32_t numRotations = static_cast<uint32_t>(rotations.size());
+				fout.write(reinterpret_cast<const char*>(&numRotations), sizeof(numRotations));
+				for (const auto& rot : rotations) {
+					fout.write(reinterpret_cast<const char*>(&rot.timeStamp), sizeof(float));
+					fout.write(reinterpret_cast<const char*>(&rot.orientation), sizeof(glm::quat));
+				}
+
+				const auto& scales = bone.m_Scales;
+				uint32_t numScales = static_cast<uint32_t>(scales.size());
+				fout.write(reinterpret_cast<const char*>(&numScales), sizeof(numScales));
+				for (const auto& scale : scales) {
+					fout.write(reinterpret_cast<const char*>(&scale.timeStamp), sizeof(float));
+					fout.write(reinterpret_cast<const char*>(&scale.scale), sizeof(glm::vec3));
+				}
+			}
+
+			WriteAssimpNodeData(fout, animation->GetRootNode());
+		}
+	}
+
+	LOG(LogType::LOG_INFO, "Animación esqueletal guardada correctamente: %s", fullPath.c_str());
+}
+
+void SkeletalAnimationComponent::WriteAssimpNodeData(std::ofstream& fout, const AssimpNodeData& node) const
+{
+	fout.write(reinterpret_cast<const char*>(&node.transformation), sizeof(glm::mat4));
+
+	uint32_t nameLength = static_cast<uint32_t>(node.name.length());
+	fout.write(reinterpret_cast<const char*>(&nameLength), sizeof(nameLength));
+	fout.write(node.name.c_str(), nameLength);
+
+	fout.write(reinterpret_cast<const char*>(&node.childrenCount), sizeof(node.childrenCount));
+
+	for (const auto& child : node.children) {
+		WriteAssimpNodeData(fout, child);
+	}
+}
+
+bool SkeletalAnimationComponent::LoadBinary(const std::string& filename)
+{
+	std::string fullPath = "Library/Animation/" + filename + ".anim";
+
+	std::ifstream fin(fullPath, std::ios::binary);
+	if (!fin.is_open()) {
+		LOG(LogType::LOG_ERROR, "Error al cargar la animación esqueletal: %s", fullPath.c_str());
+		return false;
+	}
+
+	fin.read(reinterpret_cast<char*>(&isPlaying), sizeof(isPlaying));
+	fin.read(reinterpret_cast<char*>(&animationIndex), sizeof(animationIndex));
+
+	uint32_t numAnimations;
+	fin.read(reinterpret_cast<char*>(&numAnimations), sizeof(numAnimations));
+
+	animations.clear();
+
+	for (uint32_t i = 0; i < numAnimations; ++i) {
+		auto animation = std::make_unique<Animation>();
+
+		uint32_t nameLength;
+		fin.read(reinterpret_cast<char*>(&nameLength), sizeof(nameLength));
+		std::string animName(nameLength, '\0');
+		fin.read(&animName[0], nameLength);
+		animation->GetName() = animName;
+
+		float duration;
+		int ticksPerSecond;
+		fin.read(reinterpret_cast<char*>(&duration), sizeof(duration));
+		fin.read(reinterpret_cast<char*>(&ticksPerSecond), sizeof(ticksPerSecond));
+		animation->GetDuration2() = duration;
+		animation->GetTicksPerSecond2() = ticksPerSecond;
+
+		uint32_t numAnimNames;
+		fin.read(reinterpret_cast<char*>(&numAnimNames), sizeof(numAnimNames));
+		for (uint32_t j = 0; j < numAnimNames; ++j) {
+			uint32_t animNameLength;
+			fin.read(reinterpret_cast<char*>(&animNameLength), sizeof(animNameLength));
+			std::string name(animNameLength, '\0');
+			fin.read(&name[0], animNameLength);
+			animation->GetAnimations().push_back(name);
+		}
+
+		uint32_t numBones;
+		fin.read(reinterpret_cast<char*>(&numBones), sizeof(numBones));
+
+		for (uint32_t j = 0; j < numBones; ++j) {
+			uint32_t boneNameLength;
+			fin.read(reinterpret_cast<char*>(&boneNameLength), sizeof(boneNameLength));
+			std::string boneName(boneNameLength, '\0');
+			fin.read(&boneName[0], boneNameLength);
+
+			BoneInfo boneInfo;
+			fin.read(reinterpret_cast<char*>(&boneInfo.id), sizeof(boneInfo.id));
+			fin.read(reinterpret_cast<char*>(&boneInfo.offset), sizeof(glm::mat4));
+
+			animation->m_BoneInfoMap[boneName] = boneInfo;
+		}
+
+		uint32_t numBonesList;
+		fin.read(reinterpret_cast<char*>(&numBonesList), sizeof(numBonesList));
+
+		for (uint32_t j = 0; j < numBonesList; ++j) {
+			uint32_t boneNameLength;
+			fin.read(reinterpret_cast<char*>(&boneNameLength), sizeof(boneNameLength));
+			std::string boneName(boneNameLength, '\0');
+			fin.read(&boneName[0], boneNameLength);
+
+			uint32_t parentNameLength;
+			fin.read(reinterpret_cast<char*>(&parentNameLength), sizeof(parentNameLength));
+			std::string parentName(parentNameLength, '\0');
+			fin.read(&parentName[0], parentNameLength);
+
+			int boneID;
+			fin.read(reinterpret_cast<char*>(&boneID), sizeof(boneID));
+
+			aiNodeAnim* channel = new aiNodeAnim();
+
+			uint32_t numPositions;
+			fin.read(reinterpret_cast<char*>(&numPositions), sizeof(numPositions));
+			channel->mNumPositionKeys = numPositions;
+			channel->mPositionKeys = new aiVectorKey[numPositions];
+
+			for (uint32_t k = 0; k < numPositions; ++k) {
+				KeyPosition pos;
+				fin.read(reinterpret_cast<char*>(&pos.timeStamp), sizeof(float));
+				fin.read(reinterpret_cast<char*>(&pos.position), sizeof(glm::vec3));
+
+				channel->mPositionKeys[k].mTime = pos.timeStamp;
+				channel->mPositionKeys[k].mValue = aiVector3D(pos.position.x, pos.position.y, pos.position.z);
+			}
+
+			uint32_t numRotations;
+			fin.read(reinterpret_cast<char*>(&numRotations), sizeof(numRotations));
+			channel->mNumRotationKeys = numRotations;
+			channel->mRotationKeys = new aiQuatKey[numRotations];
+
+			for (uint32_t k = 0; k < numRotations; ++k) {
+				KeyRotation rot;
+				fin.read(reinterpret_cast<char*>(&rot.timeStamp), sizeof(float));
+				fin.read(reinterpret_cast<char*>(&rot.orientation), sizeof(glm::quat));
+
+				channel->mRotationKeys[k].mTime = rot.timeStamp;
+				channel->mRotationKeys[k].mValue = aiQuaternion(rot.orientation.w, rot.orientation.x, rot.orientation.y, rot.orientation.z);
+			}
+
+			uint32_t numScales;
+			fin.read(reinterpret_cast<char*>(&numScales), sizeof(numScales));
+			channel->mNumScalingKeys = numScales;
+			channel->mScalingKeys = new aiVectorKey[numScales];
+
+			for (uint32_t k = 0; k < numScales; ++k) {
+				KeyScale scale;
+				fin.read(reinterpret_cast<char*>(&scale.timeStamp), sizeof(float));
+				fin.read(reinterpret_cast<char*>(&scale.scale), sizeof(glm::vec3));
+
+				channel->mScalingKeys[k].mTime = scale.timeStamp;
+				channel->mScalingKeys[k].mValue = aiVector3D(scale.scale.x, scale.scale.y, scale.scale.z);
+			}
+
+			Bone bone(boneName, parentName, boneID, channel);
+			animation->m_Bones.push_back(bone);
+		}
+
+		animation->m_RootNode = ReadAssimpNodeData(fin);
+
+		animations.push_back(std::move(animation));
+	}
+
+	if (!animations.empty()) {
+		testAnimation = std::make_unique<Animation>(*animations[animationIndex]);
+	}
+
+	Start();
+
+	LOG(LogType::LOG_INFO, "Animación esqueletal cargada correctamente: %s", fullPath.c_str());
+	return true;
+}
+
+AssimpNodeData SkeletalAnimationComponent::ReadAssimpNodeData(std::ifstream& fin)
+{
+	AssimpNodeData node;
+
+	fin.read(reinterpret_cast<char*>(&node.transformation), sizeof(glm::mat4));
+
+	uint32_t nameLength;
+	fin.read(reinterpret_cast<char*>(&nameLength), sizeof(nameLength));
+	node.name.resize(nameLength);
+	fin.read(&node.name[0], nameLength);
+
+	fin.read(reinterpret_cast<char*>(&node.childrenCount), sizeof(node.childrenCount));
+
+	for (int i = 0; i < node.childrenCount; ++i) {
+		node.children.push_back(ReadAssimpNodeData(fin));
+	}
+
+	return node;
 }

--- a/MyGameMaker/MyAnimationEngine/SkeletalAnimationComponent.h
+++ b/MyGameMaker/MyAnimationEngine/SkeletalAnimationComponent.h
@@ -98,6 +98,13 @@ public:
     MonoObject* CsharpReference = nullptr;
     MonoObject* GetSharp() override;
 
+	void SaveBinary(const std::string& filename) const;
+	bool LoadBinary(const std::string& filename);
+
+	void WriteAssimpNodeData(std::ofstream& fout, const AssimpNodeData& node) const;
+	static AssimpNodeData ReadAssimpNodeData(std::ifstream& fin);
+
+
     std::string serializeMat4(const glm::mat4& mat) {
         std::ostringstream oss;
         for (int i = 0; i < 4; ++i) {
@@ -164,7 +171,7 @@ protected:
     YAML::Node encode() override {
         YAML::Node node = Component::encode();
 
-        for (const auto& animation : animations) {
+        /*for (const auto& animation : animations) {
             if (animation) {
                 YAML::Node animNode;
                 animNode["name"] = animation->GetName();
@@ -232,7 +239,11 @@ protected:
 
                 node["animations"].push_back(animNode);
             }
-        }
+        }*/
+
+        std::string animName = "skeletal_anim_" + std::to_string(reinterpret_cast<uintptr_t>(this));
+        SaveBinary(animName);
+        node["animation_file"] = animName;
 
         return node;
     }
@@ -241,7 +252,7 @@ protected:
         if (!Component::decode(node))
             return false;
 
-        animations.clear();
+        /*animations.clear();
 
         if (node["animations"]) {
             for (const auto& animNode : node["animations"]) {
@@ -365,7 +376,13 @@ protected:
             testAnimation = std::make_unique<Animation>(*animations[0]);
         }
 
-        Start();
+        Start();*/
+
+		if (node["animation_file"]) {
+			std::string animName = node["animation_file"].as<std::string>();
+			LoadBinary(animName);
+		}
+
         return true;
     }
 

--- a/MyGameMaker/MyAnimationEngine/SkeletalAnimationComponent.h
+++ b/MyGameMaker/MyAnimationEngine/SkeletalAnimationComponent.h
@@ -241,7 +241,7 @@ protected:
             }
         }*/
 
-        std::string animName = "skeletal_anim_" + std::to_string(reinterpret_cast<uintptr_t>(this));
+        std::string animName = "skeletal_anim_" +  owner->GetName();
         SaveBinary(animName);
         node["animation_file"] = animName;
 

--- a/MyGameMaker/MyGameEngine/Mesh.h
+++ b/MyGameMaker/MyGameEngine/Mesh.h
@@ -23,42 +23,42 @@
 #include "Model.h"
 
 namespace YAML {
-    template <>
-    struct convert<vec2> {
-        static Node encode(const vec2& rhs) {
-            Node node;
-            node.push_back(rhs.x);
-            node.push_back(rhs.y);
-            return node;
-        }
-        static bool decode(const Node& node, vec2& rhs) {
-            if (!node.IsSequence() || node.size() != 2)
-                return false;
-            rhs.x = node[0].as<float>();
-            rhs.y = node[1].as<float>();
-            return true;
-        }
-    };
-
-    template <>
-    struct convert<vec3> {
-        static Node encode(const vec3& rhs) {
-            Node node;
-            node.push_back(rhs.x);
-            node.push_back(rhs.y);
-            node.push_back(rhs.z);
-            return node;
-        }
-        static bool decode(const Node& node, vec3& rhs) {
-            if (!node.IsSequence() || node.size() != 3)
-                return false;
-            rhs.x = node[0].as<float>();
-            rhs.y = node[1].as<float>();
-            rhs.z = node[2].as<float>();
-            return true;
-        }
-    };
 	template <>
+	struct convert<vec2> {
+		static Node encode(const vec2& rhs) {
+			Node node;
+			node.push_back(rhs.x);
+			node.push_back(rhs.y);
+			return node;
+		}
+		static bool decode(const Node& node, vec2& rhs) {
+			if (!node.IsSequence() || node.size() != 2)
+				return false;
+			rhs.x = node[0].as<float>();
+			rhs.y = node[1].as<float>();
+			return true;
+		}
+	};
+
+	template <>
+	struct convert<vec3> {
+		static Node encode(const vec3& rhs) {
+			Node node;
+			node.push_back(rhs.x);
+			node.push_back(rhs.y);
+			node.push_back(rhs.z);
+			return node;
+		}
+		static bool decode(const Node& node, vec3& rhs) {
+			if (!node.IsSequence() || node.size() != 3)
+				return false;
+			rhs.x = node[0].as<float>();
+			rhs.y = node[1].as<float>();
+			rhs.z = node[2].as<float>();
+			return true;
+		}
+	};
+	/*template <>
 	struct convert<BoundingBox> {
 		static Node encode(const BoundingBox& rhs) {
 			Node node;
@@ -75,69 +75,69 @@ namespace YAML {
 		}
 	};
 	template <>
-    struct convert<ModelData> {
-        static Node encode(const ModelData& rhs) {
-            Node node;
-            node["vBPosID"] = rhs.vBPosID;
-            node["vBNormalsID"] = rhs.vBNormalsID;
-            node["vBColorsID"] = rhs.vBColorsID;
-            node["vBTCoordsID"] = rhs.vBTCoordsID;
-            node["vBTangentsID"] = rhs.vBTangentsID;
-            node["vBBitangentsID"] = rhs.vBBitangentsID;
-            node["iBID"] = rhs.iBID;
-            node["vA"] = rhs.vA;
-            node["vertexData"] = rhs.vertexData;
-            node["indexData"] = rhs.indexData;
-            node["vertex_texCoords"] = rhs.vertex_texCoords;
-            node["vertex_normals"] = rhs.vertex_normals;
-            node["vertex_colors"] = rhs.vertex_colors;
-            node["vertex_tangents"] = rhs.vertex_tangents;
-            node["vertex_bitangents"] = rhs.vertex_bitangents;
-            return node;
-        }
-        static bool decode(const Node& node, ModelData& rhs) {
-            if (!node["vBPosID"] || !node["vBNormalsID"] || !node["vBColorsID"] || !node["vBTCoordsID"] || !node["vBTangentsID"] || !node["vBBitangentsID"] || !node["iBID"] || !node["vA"] || !node["vertexData"] || !node["indexData"] || !node["vertex_texCoords"] || !node["vertex_normals"] || !node["vertex_colors"] || !node["vertex_tangents"] || !node["vertex_bitangents"])
-                return false;
-            rhs.vBPosID = node["vBPosID"].as<unsigned int>();
-            rhs.vBNormalsID = node["vBNormalsID"].as<unsigned int>();
-            rhs.vBColorsID = node["vBColorsID"].as<unsigned int>();
-            rhs.vBTCoordsID = node["vBTCoordsID"].as<unsigned int>();
-            rhs.vBTangentsID = node["vBTangentsID"].as<unsigned int>();
-            rhs.vBBitangentsID = node["vBBitangentsID"].as<unsigned int>();
-            rhs.iBID = node["iBID"].as<unsigned int>();
-            rhs.vA = node["vA"].as<unsigned int>();
-            rhs.vertexData = node["vertexData"].as<std::vector<Vertex>>();
-            rhs.indexData = node["indexData"].as<std::vector<unsigned int>>();
-            rhs.vertex_texCoords = node["vertex_texCoords"].as<std::vector<vec2>>();
-            rhs.vertex_normals = node["vertex_normals"].as<std::vector<vec3>>();
-            rhs.vertex_colors = node["vertex_colors"].as<std::vector<vec3>>();
-            rhs.vertex_tangents = node["vertex_tangents"].as<std::vector<vec3>>();
-            rhs.vertex_bitangents = node["vertex_bitangents"].as<std::vector<vec3>>();
-            return true;
-        }
-    };
-    template <>
-    struct convert<Vertex> {
-        static Node encode(const Vertex& rhs) {
-            Node node;
-            node["position"] = rhs.position;
-            for (int i = 0; i < MAX_BONE_INFLUENCE; ++i) {
-                node["boneIDs"].push_back(rhs.m_BoneIDs[i]);
-                node["weights"].push_back(rhs.m_Weights[i]);
-            }
-            return node;
-        }
-        static bool decode(const Node& node, Vertex& rhs) {
-            if (!node["position"] || !node["boneIDs"] || !node["weights"])
-                return false;
-            rhs.position = node["position"].as<vec3>();
-            for (int i = 0; i < MAX_BONE_INFLUENCE; ++i) {
-                rhs.m_BoneIDs[i] = node["boneIDs"][i].as<int>();
-                rhs.m_Weights[i] = node["weights"][i].as<float>();
-            }
-            return true;
-        }
-    };
+	struct convert<ModelData> {
+		static Node encode(const ModelData& rhs) {
+			Node node;
+			node["vBPosID"] = rhs.vBPosID;
+			node["vBNormalsID"] = rhs.vBNormalsID;
+			node["vBColorsID"] = rhs.vBColorsID;
+			node["vBTCoordsID"] = rhs.vBTCoordsID;
+			node["vBTangentsID"] = rhs.vBTangentsID;
+			node["vBBitangentsID"] = rhs.vBBitangentsID;
+			node["iBID"] = rhs.iBID;
+			node["vA"] = rhs.vA;
+			node["vertexData"] = rhs.vertexData;
+			node["indexData"] = rhs.indexData;
+			node["vertex_texCoords"] = rhs.vertex_texCoords;
+			node["vertex_normals"] = rhs.vertex_normals;
+			node["vertex_colors"] = rhs.vertex_colors;
+			node["vertex_tangents"] = rhs.vertex_tangents;
+			node["vertex_bitangents"] = rhs.vertex_bitangents;
+			return node;
+		}
+		static bool decode(const Node& node, ModelData& rhs) {
+			if (!node["vBPosID"] || !node["vBNormalsID"] || !node["vBColorsID"] || !node["vBTCoordsID"] || !node["vBTangentsID"] || !node["vBBitangentsID"] || !node["iBID"] || !node["vA"] || !node["vertexData"] || !node["indexData"] || !node["vertex_texCoords"] || !node["vertex_normals"] || !node["vertex_colors"] || !node["vertex_tangents"] || !node["vertex_bitangents"])
+				return false;
+			rhs.vBPosID = node["vBPosID"].as<unsigned int>();
+			rhs.vBNormalsID = node["vBNormalsID"].as<unsigned int>();
+			rhs.vBColorsID = node["vBColorsID"].as<unsigned int>();
+			rhs.vBTCoordsID = node["vBTCoordsID"].as<unsigned int>();
+			rhs.vBTangentsID = node["vBTangentsID"].as<unsigned int>();
+			rhs.vBBitangentsID = node["vBBitangentsID"].as<unsigned int>();
+			rhs.iBID = node["iBID"].as<unsigned int>();
+			rhs.vA = node["vA"].as<unsigned int>();
+			rhs.vertexData = node["vertexData"].as<std::vector<Vertex>>();
+			rhs.indexData = node["indexData"].as<std::vector<unsigned int>>();
+			rhs.vertex_texCoords = node["vertex_texCoords"].as<std::vector<vec2>>();
+			rhs.vertex_normals = node["vertex_normals"].as<std::vector<vec3>>();
+			rhs.vertex_colors = node["vertex_colors"].as<std::vector<vec3>>();
+			rhs.vertex_tangents = node["vertex_tangents"].as<std::vector<vec3>>();
+			rhs.vertex_bitangents = node["vertex_bitangents"].as<std::vector<vec3>>();
+			return true;
+		}
+	};
+	template <>
+	struct convert<Vertex> {
+		static Node encode(const Vertex& rhs) {
+			Node node;
+			node["position"] = rhs.position;
+			for (int i = 0; i < MAX_BONE_INFLUENCE; ++i) {
+				node["boneIDs"].push_back(rhs.m_BoneIDs[i]);
+				node["weights"].push_back(rhs.m_Weights[i]);
+			}
+			return node;
+		}
+		static bool decode(const Node& node, Vertex& rhs) {
+			if (!node["position"] || !node["boneIDs"] || !node["weights"])
+				return false;
+			rhs.position = node["position"].as<vec3>();
+			for (int i = 0; i < MAX_BONE_INFLUENCE; ++i) {
+				rhs.m_BoneIDs[i] = node["boneIDs"][i].as<int>();
+				rhs.m_Weights[i] = node["weights"][i].as<float>();
+			}
+			return true;
+		}
+	};*/
 }
 
 class SceneSerializer;
@@ -145,10 +145,10 @@ class SceneSerializer;
 
 class Mesh {
 
-    std::vector<glm::vec3> _normals;
+    std::vector<glm::dvec3> _normals;
     std::vector<Vertex> _vertices;
     std::vector<unsigned int> _indices;
-	std::vector<glm::vec2> _texCoords;
+	std::vector<glm::dvec2> _texCoords;
 
     BoundingBox _boundingBox;
     std::vector<Mesh> subMeshes;
@@ -209,36 +209,27 @@ protected:
 
     YAML::Node encode() {
         YAML::Node node;
-        auto model = getModel();
-        node["name"] = model->GetMeshName();
-        node["model_data"] = model->GetModelData();
-        node["material_index"] = model->GetMaterialIndex();
-        node["boundingbox"] = _boundingBox;
+        std::string name = model->GetMeshName();
+        node["name"] = name;
+
+        SaveBinary(name);
+
         return node;
     }
 
     bool decode(const YAML::Node& node) {
-        Model model;
-        setModel(std::make_shared<Model>());
-        if (node["name"]) {
-            std::string name = node["name"].as<std::string>();
-            getModel()->SetMeshName(name);
-        }
 
-        if (node["model_data"]) {
-            ModelData modelData = node["model_data"].as<ModelData>();
-            getModel()->SetModelData(modelData);
-        }
+        if (!node["name"])
+			return false;
 
-        if (node["material_index"]) {
-            int materialIndex = node["material_index"].as<int>();
-            getModel()->SetMaterialIndex(materialIndex);
-        }
+        std::string name = node["name"].as<std::string>();
+        std::shared_ptr<Mesh> loadedMesh = LoadBinary(name);
+        if (!loadedMesh) {
+			return false;
+		}
 
-        if (node["boundingbox"]) {
-            BoundingBox bbox = node["boundingbox"].as<BoundingBox>();
-            setBoundingBox(bbox);
-        }
+        setModel(loadedMesh->getModel());
+        setBoundingBox(loadedMesh->boundingBox());
 
         return true;
     }


### PR DESCRIPTION
This pull request introduces significant changes to the `SkeletalAnimationComponent` and `Mesh` classes, focusing on adding binary serialization and deserialization functionality. The most important changes include adding methods for saving and loading binary data, modifying existing methods to support these new functionalities, and updating data structures to accommodate the changes.

### Changes to `SkeletalAnimationComponent`:

* Added `SaveBinary` and `LoadBinary` methods for saving and loading skeletal animation data in binary format. These methods handle the serialization and deserialization of various animation properties, including bone transformations and animation keyframes. [[1]](diffhunk://#diff-da988246bfcfbfc7fe95a611697af54c30df2873e49c556f8b6fe7321951c927R113-R388) [[2]](diffhunk://#diff-a5253e78bf8c64f3ce3d2a7bcaecc89148de2c44e42071e48b092ea5e4e7171cR101-R107)
* Introduced helper methods `WriteAssimpNodeData` and `ReadAssimpNodeData` to assist with the recursive serialization and deserialization of node data. [[1]](diffhunk://#diff-da988246bfcfbfc7fe95a611697af54c30df2873e49c556f8b6fe7321951c927R113-R388) [[2]](diffhunk://#diff-a5253e78bf8c64f3ce3d2a7bcaecc89148de2c44e42071e48b092ea5e4e7171cR101-R107)
* Updated the `encode` and `decode` methods to use the new binary serialization methods instead of YAML serialization for animations. [[1]](diffhunk://#diff-a5253e78bf8c64f3ce3d2a7bcaecc89148de2c44e42071e48b092ea5e4e7171cL167-R174) [[2]](diffhunk://#diff-a5253e78bf8c64f3ce3d2a7bcaecc89148de2c44e42071e48b092ea5e4e7171cL235-R246) [[3]](diffhunk://#diff-a5253e78bf8c64f3ce3d2a7bcaecc89148de2c44e42071e48b092ea5e4e7171cL244-R255) [[4]](diffhunk://#diff-a5253e78bf8c64f3ce3d2a7bcaecc89148de2c44e42071e48b092ea5e4e7171cL368-R385)

### Changes to `Mesh`:

* Enhanced the `SaveBinary` and `LoadBinary` methods to support saving and loading mesh data, including vertex data, indices, and other attributes. These methods now handle the serialization of additional properties such as texture coordinates, normals, colors, tangents, and bitangents. [[1]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5R861-R921) [[2]](diffhunk://#diff-3644a49fb821053fdd69f24eeb2f39311607b8533b55e3d939cfc1940d6d51b5R940-R1017)
* Modified the `loadToOpenGL` method to utilize the deserialized vertex data directly.
* Commented out the YAML conversion code for `BoundingBox` in `Mesh.h`, indicating a shift towards binary serialization. [[1]](diffhunk://#diff-54a0800c8ea6dd72df8fa0a905d70c128ca123eb956a5a7c10a931870c524384L61-R61) [[2]](diffhunk://#diff-54a0800c8ea6dd72df8fa0a905d70c128ca123eb956a5a7c10a931870c524384L140-R151)