### PR TITLE
Framerate cap added

### DIFF
--- a/MyGameMaker/MyGameEditor/App.cpp
+++ b/MyGameMaker/MyGameEditor/App.cpp
@@ -209,6 +209,16 @@ void App::FinishUpdate()
 		dt = HIGH_LIMIT;
 	}
 
+	if (frameRateCap > 0 && dt < frameRateCap && capFrames)
+	{
+		glm::uint32 delay = (frameRateCap - dt);
+
+		if (delay > 0)
+		{
+			SDL_Delay(delay);
+		}
+	}
+
 	lastTime = now;
 
 

--- a/MyGameMaker/MyGameEditor/App.h
+++ b/MyGameMaker/MyGameEditor/App.h
@@ -84,7 +84,9 @@ private:
 	std::chrono::duration<double> targetFrameDuration;
 	std::chrono::steady_clock::time_point frameStart, frameEnd;
 
-	int frameRate = 240;
+	bool capFrames = true; //false para tener el maximo de fps posible
+	int frameRate = 240; //Fake frameRate no borro por si acaso
+	glm::uint32 frameRateCap = 16.67; //forlmula para saber que numero poner aqui: 1000ms / desired fps ej: 1000ms / 60fps = 16,67
 	double dt = 0;
 	double dtCount = 0;
 	int frameCount = 0;


### PR DESCRIPTION
This pull request introduces changes to the `App` class in `MyGameMaker/MyGameEditor` to implement frame rate capping functionality. The most important changes include adding a delay mechanism in the `FinishUpdate` method and introducing new member variables to control frame rate capping.

Frame rate capping functionality:

* [`MyGameMaker/MyGameEditor/App.cpp`](diffhunk://#diff-8f554abe5ca729ea7be5729f51aa46f082f1a378ca4bf2f8891ad38ec5d25eb3R212-R221): Added a block in the `FinishUpdate` method to introduce a delay if the frame rate cap is set and the current frame time is below the cap.
* [`MyGameMaker/MyGameEditor/App.h`](diffhunk://#diff-9196ecf41035c265f63a004fa29afedcf5a1d0d0d98ec972b850c10ac8b5953fL87-R89): Added `capFrames` and `frameRateCap` member variables to control whether frames should be capped and to store the frame rate cap value, respectively.