### PR TITLE
Fix physics

### DIFF
--- a/MyGameMaker/MyPhysicsEngine/PhysicsModule.cpp
+++ b/MyGameMaker/MyPhysicsEngine/PhysicsModule.cpp
@@ -9,7 +9,7 @@
 #include "MeshColliderComponent.h"
 
 
-constexpr float fixedDeltaTime = 0.02; // 60 updates per second //With 0.02 it goes a little bit laggy
+constexpr float fixedDeltaTime = 0.01; // 60 updates per second //With 0.02 it goes a little bit laggy
 float accumulatedTime = 0.0f;
 
 
@@ -55,7 +55,7 @@ void PhysicsModule::SyncTransforms() {
     static std::unordered_map<GameObject*, glm::dvec3> offsetMap;
 
     // Compute interpolation factor (between 0 and 1)
-    float interpolationFactor = glm::clamp((dynamicsWorld->getSolverInfo().m_timeStep - fixedDeltaTime) / fixedDeltaTime, 0.0f, 1.0f);
+    float interpolationFactor = accumulatedTime / fixedDeltaTime;
 
 
     for (auto& [gameObject, rigidBody] : gameObjectRigidBodyMap) {      

--- a/MyGameMaker/MyPhysicsEngine/PhysicsModule.cpp
+++ b/MyGameMaker/MyPhysicsEngine/PhysicsModule.cpp
@@ -9,7 +9,7 @@
 #include "MeshColliderComponent.h"
 
 
-constexpr float fixedDeltaTime = 0.01; // 60 updates per second //With 0.02 it goes a little bit laggy
+constexpr float fixedDeltaTime = 0.02; // 60 updates per second //With 0.02 it goes a little bit laggy
 float accumulatedTime = 0.0f;
 
 
@@ -55,7 +55,8 @@ void PhysicsModule::SyncTransforms() {
     static std::unordered_map<GameObject*, glm::dvec3> offsetMap;
 
     // Compute interpolation factor (between 0 and 1)
-    float interpolationFactor = accumulatedTime / fixedDeltaTime;
+    float interpolationFactor = glm::clamp((dynamicsWorld->getSolverInfo().m_timeStep - fixedDeltaTime) / fixedDeltaTime, 0.0f, 1.0f);
+
 
     for (auto& [gameObject, rigidBody] : gameObjectRigidBodyMap) {      
 
@@ -271,11 +272,11 @@ void PhysicsModule::DrawDebugDrawer() {
 
 
 void PhysicsModule::CallMonoCollision(GameObject* obj, const std::string& methodName, GameObject* other) {
-    if (!obj) return;
-
+    if (!obj || !other) return;
+    auto s = *other;
     for (auto& script : obj->scriptComponents) {
         if (script) {
-            script->InvokeMonoMethod(methodName, other);
+            script->InvokeMonoMethod(methodName, *other);
         }
     }
 }
@@ -340,8 +341,8 @@ void PhysicsModule::CheckCollisions() {
                     CallMonoCollision(objB, "OnTriggerEnter", objA);
                 }
                 else {
-                    colliderA->OnCollisionEnter(colliderB);
-                    colliderB->OnCollisionEnter(colliderA);
+                    /*colliderA->OnCollisionEnter(colliderB);
+                    colliderB->OnCollisionEnter(colliderA);*/
 
                     CallMonoCollision(objA, "OnCollisionEnter", objB);
                     CallMonoCollision(objB, "OnCollisionEnter", objA);
@@ -441,7 +442,8 @@ bool PhysicsModule::Update(double dt) {
 #endif // !_BUILD
   
     if (linkPhysicsToScene) {
-		dynamicsWorld->stepSimulation(dt, 16, fixedDeltaTime);
+        int numSubsteps = glm::clamp(static_cast<int>(dt / fixedDeltaTime), 1, 10);
+        dynamicsWorld->stepSimulation(dt, numSubsteps, fixedDeltaTime);
 		SyncTransforms();
         CheckCollisions();
     }

--- a/MyGameMaker/MyScriptingEngine/ScriptComponent.cpp
+++ b/MyGameMaker/MyScriptingEngine/ScriptComponent.cpp
@@ -166,16 +166,47 @@ std::string ScriptComponent::GetTypeName() const
 	return "";
 }
 
-void ScriptComponent::InvokeMonoMethod(const std::string& methodName, GameObject* other) {
+
+
+MonoObject* GetMonoObjectFromGameObject(GameObject* gameObject) {
+    if (!gameObject) return nullptr;
+
+    MonoClass* gameObjectClass = MonoManager::GetInstance().GetClass("HawkEngine", "GameObject");
+    if (!gameObjectClass) {    
+        return nullptr;
+    }
+
+    MonoObject* monoGameObject = mono_object_new(mono_domain_get(), gameObjectClass);
+    if (!monoGameObject) {
+        return nullptr;
+    }
+
+    MonoClassField* nativePtrField = mono_class_get_field_from_name(gameObjectClass, "CplusplusInstance");
+    if (!nativePtrField) {
+        return nullptr;
+    }
+
+    uintptr_t nativePtr = reinterpret_cast<uintptr_t>(gameObject);
+    mono_field_set_value(monoGameObject, nativePtrField, &nativePtr);
+
+    return monoGameObject;
+}
+
+void ScriptComponent::InvokeMonoMethod(const std::string& methodName, GameObject& other) {
     if (!monoScript) return;
 
     MonoClass* klass = mono_object_get_class(monoScript);
     MonoMethod* method = mono_class_get_method_from_name(klass, methodName.c_str(), 1);
 
-    if (method) {
-        void* args[1];
-        uintptr_t otherPtr = reinterpret_cast<uintptr_t>(other);
-        args[0] = &otherPtr;
-        mono_runtime_invoke(method, monoScript, args, nullptr);
+    if (!method) return;
+
+    MonoObject* monoOther = GetMonoObjectFromGameObject(&other);
+
+    if (!monoOther) {
+        return;
     }
+
+    void* args[1];
+    args[0] = monoOther; 
+    mono_runtime_invoke(method, monoScript, args, nullptr);
 }

--- a/MyGameMaker/MyScriptingEngine/ScriptComponent.h
+++ b/MyGameMaker/MyScriptingEngine/ScriptComponent.h
@@ -27,7 +27,7 @@ public:
     MonoObject* GetSharpObject() const { return monoScript; }
     std::string GetTypeName() const;
 
-    void InvokeMonoMethod(const std::string& methodName, GameObject* other);
+	void InvokeMonoMethod(const std::string& methodName, GameObject& other);
 
     MonoObject* monoScript = nullptr;
 

--- a/MyGameMaker/Script/Collider.cs
+++ b/MyGameMaker/Script/Collider.cs
@@ -36,7 +36,7 @@ namespace HawkEngine
         [MethodImpl(MethodImplOptions.InternalCall)]
         public extern void SnapToPosition();
 
-        private GameObject owner;
+        public GameObject owner;
 
         public Collider(UIntPtr nativeCollider, GameObject owner)
         {

--- a/MyGameMaker/Script/Grenade.cs
+++ b/MyGameMaker/Script/Grenade.cs
@@ -69,7 +69,7 @@ public class Grenade : MonoBehaviour
         isExploded = true;
     }
 
-    public override void OnCollisionEnter(Collider other)
+    public override void OnCollisionEnter(GameObject other)
     {
         Explode();
     }

--- a/MyGameMaker/Script/MonoBehaviour.cs
+++ b/MyGameMaker/Script/MonoBehaviour.cs
@@ -35,18 +35,18 @@ public  class MonoBehaviour
     }
 
     // --- Collision Events (Overridable) ---
-    public virtual void OnCollisionEnter(Collider other) {
+    public virtual void OnCollisionEnter(GameObject other) {
     }
-    public virtual void OnCollisionStay(Collider other) {
+    public virtual void OnCollisionStay(GameObject other) {
     }
-    public virtual void OnCollisionExit(Collider other) {
-    }
-
-    public virtual void OnTriggerEnter(Collider other) {
+    public virtual void OnCollisionExit(GameObject other) {
     }
 
-    public virtual void OnTriggerStay(Collider other) {
+    public virtual void OnTriggerEnter(GameObject other) {
     }
-    public virtual void OnTriggerExit(Collider other) {
+
+    public virtual void OnTriggerStay(GameObject other) {
+    }
+    public virtual void OnTriggerExit(GameObject other) {
     }
 }

--- a/MyGameMaker/Script/PlayerMovement.cs
+++ b/MyGameMaker/Script/PlayerMovement.cs
@@ -86,32 +86,41 @@ public class PlayerMovement : MonoBehaviour
         }
     }
 
-    override public void OnCollisionEnter(Collider other)
+    override public void OnCollisionEnter(GameObject other)
     {
-        Engineson.print("Player Collision Enter:");
+        if (other != null)
+        {
+            Engineson.print("OnCollisionEnter con: " + other.name);
+            Engineson.print(other.GetComponent<Collider>().name);
+        }
+        else
+        {
+            Engineson.print("Error: GameObject other es nulo");
+
+        }
     }
 
-    override public void OnCollisionStay(Collider other)
+    override public void OnCollisionStay(GameObject other)
     {
         Engineson.print("Player Collision Stay: ");
     }
 
-    override public void OnCollisionExit(Collider other)
+    override public void OnCollisionExit(GameObject other)
     {
         Engineson.print("Player Collision Exit: ");
     }
 
-    override public void OnTriggerEnter(Collider other)
+    override public void OnTriggerEnter(GameObject other)
     {
         Engineson.print("Player Trigger Enter: ");
     }
 
-    override public void OnTriggerStay(Collider other)
+    override public void OnTriggerStay(GameObject other)
     {
         Engineson.print("Player Trigger Stay: ");
     }
 
-    override public void OnTriggerExit(Collider other)
+    override public void OnTriggerExit(GameObject other)
     {
         Engineson.print("Player Trigger Exit: ");
     }


### PR DESCRIPTION
This pull request includes several changes to improve the physics and scripting components of the game engine. The most important changes focus on collision handling, method invocation, and synchronization.

### Improvements to collision handling:

* [`MyGameMaker/MyPhysicsEngine/PhysicsModule.cpp`](diffhunk://#diff-b89af48608b0bc75cf39b40412bbe8d94a05b9fb12af129f22990b120680f420L274-R279): Updated `CallMonoCollision` to check if both `obj` and `other` are not null before proceeding, and modified the method to use a reference to `other` instead of a pointer.
* [`MyGameMaker/MyPhysicsEngine/PhysicsModule.cpp`](diffhunk://#diff-b89af48608b0bc75cf39b40412bbe8d94a05b9fb12af129f22990b120680f420L343-R345): Commented out direct calls to `OnCollisionEnter` methods of colliders and replaced them with `CallMonoCollision` calls in `CheckCollisions`.
* [`MyGameMaker/Script/MonoBehaviour.cs`](diffhunk://#diff-4f7c74ab0e16abcca3c6bd10983c62510f2702c1bffc55d48b72f3c2dab2af3fL38-R50): Changed the parameter type of collision event methods (`OnCollisionEnter`, `OnCollisionStay`, `OnCollisionExit`, `OnTriggerEnter`, `OnTriggerStay`, `OnTriggerExit`) from `Collider` to `GameObject`.

### Method invocation improvements:

* [`MyGameMaker/MyScriptingEngine/ScriptComponent.cpp`](diffhunk://#diff-9c2658674e2a45c2c4210282fdf0fa686f8ab9590f13870a78af61fe5f4614b4L169-L181): Added a helper function `GetMonoObjectFromGameObject` to convert a `GameObject` to a `MonoObject`, and updated `InvokeMonoMethod` to use this helper function.
* [`MyGameMaker/MyScriptingEngine/ScriptComponent.h`](diffhunk://#diff-a8d84312ef8cfc714f134369fc1043d1de422842b900a5501c72dfbc5c893e4fL30-R30): Updated the `InvokeMonoMethod` declaration to use a reference to `GameObject` instead of a pointer.

### Synchronization and other improvements:

* [`MyGameMaker/MyPhysicsEngine/PhysicsModule.cpp`](diffhunk://#diff-b89af48608b0bc75cf39b40412bbe8d94a05b9fb12af129f22990b120680f420L444-R446): Added a calculation for the number of substeps in `Update` to improve the accuracy of the physics simulation.
* [`MyGameMaker/Script/Collider.cs`](diffhunk://#diff-7bac2c725c42b01776c116fd012221aef2cdeb208e7a793543ad714b15186f4cL39-R39): Changed the `owner` field from private to public to allow external access.
* [`MyGameMaker/Script/PlayerMovement.cs`](diffhunk://#diff-f821775598606ddad43f410ac61f1ec8d7a0a0c057869177aee4dfff0a79399eL89-R123): Enhanced the collision and trigger methods to include null checks and additional logging for debugging purposes.