### PR TITLE
finished local space particles

### DIFF
--- a/MyGameMaker/MyGameEditor/UIInspector.cpp
+++ b/MyGameMaker/MyGameEditor/UIInspector.cpp
@@ -2056,6 +2056,13 @@ private:
 			system->SetParticleAlpha(system->GetStartAlpha(), endColorArr[3]);
 		}
 
+		ImGui::Text("IsLocalSpace");
+
+		bool isLocalSpace = system->GetIsLocalSpace();
+		if (ImGui::Checkbox("##IsLocalSpace", &isLocalSpace)) {
+			system->SetIsLocalSpace(isLocalSpace);
+		}
+
 		ImGui::EndGroup();
 		ImGui::TreePop();
 	}

--- a/MyGameMaker/MyParticlesEngine/ParticleData.h
+++ b/MyGameMaker/MyParticlesEngine/ParticleData.h
@@ -2,6 +2,7 @@
 #include <glm/glm.hpp>
 #include <vector>
 #include <GL/glew.h>
+#include "MyGameEngine/GameObject.h"
 
 struct ParticleData {
 	bool playOnAwake;
@@ -30,6 +31,8 @@ struct ParticleData {
 	float indexTimer;
 	int animIndex;
 	float animSpeed;
+	GameObject* parent;
+	bool isLocalSpace;
 
 	ParticleData()
 		: playOnAwake(false)
@@ -227,6 +230,8 @@ public:
 
 			particleData[i].velocity += particleData[i].gravity * deltaTime;
 			particleData[i].age += deltaTime;
+
+
 			particleData[i].position += particleData[i].velocity * deltaTime;
 
 			
@@ -278,7 +283,16 @@ public:
 			InstanceData instance;
 			instance.playOnAwake = particleData[i].playOnAwake;
 			instance.duration = particleData[i].duration;
-			instance.position = particleData[i].position;
+
+			if (particleData[i].isLocalSpace) 
+			{
+				instance.position = particleData[i].position + (glm::vec3)particleData[i].parent->GetTransform()->GetPosition();
+			}
+			else 
+			{
+				instance.position = particleData[i].position;
+			}
+
 			instance.color = particleData[i].color;
 			instance.endColor = particleData[i].endColor;
 			instance.size = particleData[i].size;

--- a/MyGameMaker/MyParticlesEngine/ParticleFX.cpp
+++ b/MyGameMaker/MyParticlesEngine/ParticleFX.cpp
@@ -44,7 +44,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		0.5f,						   // Min scale
 		0.0f,						   // Max scale
-		"Assets/Textures/Smoke30Frames.png" // Texture path
+		"Assets/Textures/Smoke30Frames.png", // Texture path
+		false						   // Is Local Space
 	};
 
 	const ParticlePreset Fire = {
@@ -77,8 +78,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		0.5f,						   // Min scale
 		0.0f,						   // Max scale
-		"Assets/Textures/Smoke30Frames.png" // Texture path
-
+		"Assets/Textures/Smoke30Frames.png", // Texture path
+		false				   // Is Local Space
 	};
 
 	const ParticlePreset MuzzleFlash = {
@@ -111,7 +112,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		0.5f,						   // Min scale
 		0.0f,						   // Max scale
-		"Assets/Textures/Smoke30Frames.png" // Texture path
+		"Assets/Textures/Smoke30Frames.png", // Texture path
+		false						   // Is Local Space
 	};
 
 	const ParticlePreset Dust = {
@@ -144,7 +146,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		0.5f,						   // Min scale
 		0.0f,						   // Max scale
-		"Assets/Textures/Smoke30Frames.png" // Texture path
+		"Assets/Textures/Smoke30Frames.png", // Texture path
+		false						   // Is Local Space
 
 	};
 
@@ -178,7 +181,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		0.5f,						   // Min scale
 		0.0f,						   // Max scale
-		"Assets/Textures/Smoke30Frames.png" // Texture path
+		"Assets/Textures/Smoke30Frames.png", // Texture path
+		false						   // Is Local Space
 	};
 
 	const ParticlePreset Flame = {
@@ -211,7 +215,8 @@ namespace ParticlePresets {
 		false,						   // Random rotation
 		1.0f,						   // Min scale
 		1.0f,						   // Max scale
-		"Assets/Textures/fire_spritesheet.png" // Texture path
+		"Assets/Textures/fire_spritesheet.png", // Texture path
+		false						   // Is Local Space
 	};
 
 	const ParticlePreset Environment_Smoke = {
@@ -244,7 +249,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		1.0f,						   // Min scale
 		1.0f,						   // Max scale
-		"Assets/Textures/smoke_spritesheet.png" // Texture path
+		"Assets/Textures/smoke_spritesheet.png", // Texture path
+		false						   // Is Local Space
 	};
 
 	const ParticlePreset Environment_Explosion = {
@@ -277,7 +283,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		1.0f,						   // Min scale
 		1.0f,						   // Max scale
-		"Assets/Textures/ixplosion.png" // Texture path
+		"Assets/Textures/ixplosion.png", // Texture path
+		false						   // Is Local Space
 	};
 
 
@@ -311,7 +318,8 @@ namespace ParticlePresets {
 		false,						   // Random rotation
 		1.0f,						   // Min scale
 		1.0f,						   // Max scale
-		"Assets/Textures/muzzle.png" // Texture path
+		"Assets/Textures/muzzle.png", // Texture path
+		false						   // Is Local Space
 	};
 
 	const ParticlePreset Enemy_Dash = {
@@ -344,7 +352,8 @@ namespace ParticlePresets {
 		false,						   // Random rotation
 		1.0f,						   // Min scale
 		1.0f,						   // Max scale
-		"Assets/Textures/EnemyDash.png" // Texture path
+		"Assets/Textures/EnemyDash.png", // Texture path
+		false						   // Is Local Space
 	};
 
 
@@ -378,7 +387,8 @@ namespace ParticlePresets {
 	false,						   // Random rotation
 	1.0f,						   // Min scale
 	1.0f,						   // Max scale
-	"Assets/Textures/Acid_Splash.png" // Texture path
+	"Assets/Textures/Acid_Splash.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset Acid_Puddle = {
@@ -411,7 +421,8 @@ namespace ParticlePresets {
 	false,						   // Random rotation
 	1.0f,						   // Min scale
 	1.0f,						   // Max scale
-	"Assets/Textures/acid_puddle.png" // Texture path
+	"Assets/Textures/acid_puddle.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset Energy_Ball = {
@@ -444,7 +455,8 @@ namespace ParticlePresets {
 	false,						   // Random rotation
 	1.0f,						   // Min scale
 	1.0f,						   // Max scale
-	"Assets/Textures/ElectricityBall.png" // Texture path
+	"Assets/Textures/ElectricityBall.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset RailGun_Auto = {
@@ -477,7 +489,8 @@ namespace ParticlePresets {
 	false,						   // Random rotation
 	1.0f,						   // Min scale
 	1.0f,						   // Max scale
-	"Assets/Textures/RailGunAuto.png" // Texture path
+	"Assets/Textures/RailGunAuto.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset RailGun_Semi = {
@@ -510,7 +523,8 @@ namespace ParticlePresets {
 	false,						   // Random rotation
 	1.0f,						   // Min scale
 	1.0f,						   // Max scale
-	"Assets/Textures/RailGunSemi.png" // Texture path
+	"Assets/Textures/RailGunSemi.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset Environment_Dropplet = {
@@ -543,7 +557,8 @@ namespace ParticlePresets {
 	false,						   // Random rotation
 	0.3f,						   // Min scale
 	0.3f,						   // Max scale
-	"Assets/Textures/dropplet.png" // Texture path
+	"Assets/Textures/dropplet.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset Environment_Spark = {
@@ -576,7 +591,8 @@ namespace ParticlePresets {
 	false,						   // Random rotation
 	1.0f,						   // Min scale
 	1.0f,						   // Max scale
-	"Assets/Textures/Spark.png" // Texture path
+	"Assets/Textures/Spark.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset Arc_Snare_Impact = { // la que pone thundaaar
@@ -609,7 +625,8 @@ namespace ParticlePresets {
 	true,						   // Random rotation
 	1.0f,						   // Min scale
 	1.0f,						   // Max scale
-	"Assets/Textures/thundaaar2.png" // Texture path
+	"Assets/Textures/thundaaar2.png", // Texture path
+	false						   // Is Local Space
 	};
 
 	const ParticlePreset Medicae_Stim = {
@@ -642,7 +659,8 @@ namespace ParticlePresets {
 		true,						   // Random rotation
 		1.0f,						   // Min scale
 		1.0f,						   // Max scale
-		"Assets/Textures/Medicae_Stim.png" // Texture path
+		"Assets/Textures/Medicae_Stim.png", // Texture path
+		false 						   // Is Local Space
 	};
 
 	const ParticlePreset Blood_Splash = {
@@ -675,7 +693,8 @@ namespace ParticlePresets {
 		true,                          // Random rotation
 		10.0f,                         // Min scale
 		5.0f,                          // Max scale
-		"Assets/Textures/BloodSplash_decals1_Yiwei.png" // Texture path
+		"Assets/Textures/BloodSplash_decals1_Yiwei.png", // Texture path
+		false						   // Is Local Space
 	};
 
 }
@@ -936,7 +955,18 @@ void ParticleFX::EmitParticle() {
 	particle.maxLifetime = minLifetime + dist01(rng) * (maxLifetime - minLifetime);
 	particle.lifetime = 0.0f;
 
-	particle.position = position + GenerateRandomPosition();
+	particle.parent = owner;
+
+	particle.isLocalSpace = isLocalSpace;
+
+	if (isLocalSpace) 
+	{
+		particle.position = GenerateRandomPosition();
+	}
+	else {
+		particle.position = position + GenerateRandomPosition();
+	}
+
 
 	particle.velocity = GenerateRandomVelocity();
 
@@ -958,6 +988,7 @@ void ParticleFX::EmitParticle() {
 	{
 		particle.rotation = glm::radians(startRotation);
 	}
+
 
 	particle.rotationSpeed = rotationSpeed;
 

--- a/MyGameMaker/MyParticlesEngine/ParticleFX.h
+++ b/MyGameMaker/MyParticlesEngine/ParticleFX.h
@@ -51,6 +51,7 @@ struct ParticlePreset {
 	float minSize;
 	float maxSize;
 	std::string texturePath;
+	bool isLocalSpace;
 };
 
 namespace ParticlePresets {
@@ -116,6 +117,7 @@ public:
 	void SetRandomRotation(bool randomRotation) { this->randomRotation = randomRotation; }
 	void SetParticleEndSize(float endSize);
 	void SetRandomStartIndex(bool randomAnimIndex) { this->randomAnimIndex = randomAnimIndex; }
+	void SetIsLocalSpace(bool isLocalSpace) { this->isLocalSpace = isLocalSpace; }
 
 
 	float GetEmissionRate() const { return emissionRate; }
@@ -131,6 +133,7 @@ public:
 	float GetStartRotation() const { return startRotation; }
 	float GetMinScale() const { return minSize; }
 	float GetMaxScale() const { return maxSize; }
+	bool GetIsLocalSpace() const { return isLocalSpace; }
 	bool GetPlayOnAwake() const { return playOnAwake; }
 	bool GetUseAnimation() const { return useAnimation; }
 	bool GetRandomRotation() const { return randomRotation; }
@@ -222,7 +225,7 @@ private:
 	glm::vec3 position;
 	glm::quat rotation;
 	glm::vec3 scale;
-
+	bool isLocalSpace = false;
 	int particleTypeInt = 0;
 
 	// Spritesheet data


### PR DESCRIPTION
This pull request introduces support for "local space" particle effects, allowing particles to either follow their parent object's position or remain in world space. Key changes include updates to the particle system's data structures, rendering logic, and presets to accommodate this new feature.

### Particle System Enhancements:
* Added a new `isLocalSpace` property to the `ParticleData` and `ParticlePreset` structures, along with a `parent` pointer in `ParticleData` to reference the owning object. This enables particles to determine whether they should move relative to their parent's position or independently in world space. (`[[1]](diffhunk://#diff-19fc73cda66e353e79e3bb946b01f1c9d3f54ffe8a284fa01631f331d42d68ebR34-R35)`, `[[2]](diffhunk://#diff-936f7110b3a30a52b9c6984c9aafac73323c5b82684bc72a3742ad51d587eb2eR54)`, `[[3]](diffhunk://#diff-936f7110b3a30a52b9c6984c9aafac73323c5b82684bc72a3742ad51d587eb2eL225-R228)`)
* Updated the `ParticleFX` class to include getter and setter methods for the `isLocalSpace` property, ensuring it can be configured dynamically. (`[[1]](diffhunk://#diff-936f7110b3a30a52b9c6984c9aafac73323c5b82684bc72a3742ad51d587eb2eR120)`, `[[2]](diffhunk://#diff-936f7110b3a30a52b9c6984c9aafac73323c5b82684bc72a3742ad51d587eb2eR136)`)

### Rendering Logic Updates:
* Modified the `ParticleInstancedRenderer` to adjust particle positions based on the `isLocalSpace` property. If `isLocalSpace` is true, the particle's position is calculated relative to its parent's transform. (`[MyGameMaker/MyParticlesEngine/ParticleData.hR286-R295](diffhunk://#diff-19fc73cda66e353e79e3bb946b01f1c9d3f54ffe8a284fa01631f331d42d68ebR286-R295)`)
* Updated the `EmitParticle` method in `ParticleFX` to initialize particle positions and the `isLocalSpace` property correctly during particle emission. (`[MyGameMaker/MyParticlesEngine/ParticleFX.cppR958-R969](diffhunk://#diff-d3cba2aa0e0b61f6c55864d8dd02fcd0752653e3af223d82ba3f10b55e1a148aR958-R969)`)

### User Interface Improvements:
* Added a checkbox labeled "IsLocalSpace" in the `ComponentDrawer` class to allow users to toggle the `isLocalSpace` property directly from the editor's UI. (`[MyGameMaker/MyGameEditor/UIInspector.cppR2059-R2065](diffhunk://#diff-4f9de228261bac23abce9d831eacd36458a01c7ebcec0e951fe7bd3999d0ea44R2059-R2065)`)

### Particle Preset Updates:
* Extended all particle presets in `ParticleFX.cpp` to include the `isLocalSpace` property, defaulting to `false` (world space). This ensures backward compatibility while supporting the new feature. (`[[1]](diffhunk://#diff-d3cba2aa0e0b61f6c55864d8dd02fcd0752653e3af223d82ba3f10b55e1a148aL47-R48)`, `[[2]](diffhunk://#diff-d3cba2aa0e0b61f6c55864d8dd02fcd0752653e3af223d82ba3f10b55e1a148aL80-R82)`, `[[3]](diffhunk://#diff-d3cba2aa0e0b61f6c55864d8dd02fcd0752653e3af223d82ba3f10b55e1a148aR958-R969)`, and others)

### Dependency Management:
* Added a new include for `GameObject.h` in `ParticleData.h` to support the `parent` pointer in `ParticleData`. (`[MyGameMaker/MyParticlesEngine/ParticleData.hR5](diffhunk://#diff-19fc73cda66e353e79e3bb946b01f1c9d3f54ffe8a284fa01631f331d42d68ebR5)`)