### PR TITLE
fixed

### DIFF
--- a/MyGameMaker/MyGameEngine/GameObject.cpp
+++ b/MyGameMaker/MyGameEngine/GameObject.cpp
@@ -434,10 +434,11 @@ std::string GameObject::GetTag() const
         return "";
 	}
 
-	if (tag.empty()) {
-		return "Untagged";
-	}
-	
+    if (tag.size() > 1024) {
+        LOG(LogType::LOG_WARNING, "Tag size is abnormally large (%zu), returning empty tag", tag.size());
+        return "";
+    }
+
     return tag;
 }
 

--- a/MyGameMaker/MyGameEngine/Image.cpp
+++ b/MyGameMaker/MyGameEngine/Image.cpp
@@ -236,6 +236,10 @@ void Image::SaveBinary(const std::string& filename) const {
 		std::filesystem::create_directories("Library/Images");
 	}
 
+	if (std::filesystem::exists(fullPath)) {
+		return;
+	}
+
 	std::ofstream fout(fullPath, std::ios::binary);
 	if (!fout.is_open()) {
 		LOG(LogType::LOG_ERROR, "Failed to open file for writing: %s", fullPath.c_str());

--- a/MyGameMaker/MyGameEngine/Material.h
+++ b/MyGameMaker/MyGameEngine/Material.h
@@ -165,7 +165,7 @@ protected:
 			}
 		}
 
-		LOG(LogType::LOG_INFO, "Material loaded successfully: %s", fullPath.c_str());
+		//LOG(LogType::LOG_INFO, "Material loaded successfully: %s", fullPath.c_str());
 
         return true;
     }


### PR DESCRIPTION
This pull request includes updates to improve error handling, optimize file-saving behavior, and clean up logging in the game engine. The most important changes include adding a warning for abnormally large tags, preventing overwriting existing image files, and commenting out an unnecessary log message.

### Error Handling Improvements:
* [`MyGameMaker/MyGameEngine/GameObject.cpp`](diffhunk://#diff-f23db8992cc9ce1be1000f339dd0dc6fd178bd71e915b8a3af8c554be8cd969dL437-R439): Added a check to detect abnormally large tags (greater than 1024 characters) in `GameObject::GetTag()`. If a tag exceeds this size, a warning is logged, and an empty tag is returned.

### File-Saving Optimization:
* [`MyGameMaker/MyGameEngine/Image.cpp`](diffhunk://#diff-86e07921417313581ebdbb1183ceff4b35dd7bb169514b9820796aad48cad9a1R239-R242): Updated `Image::SaveBinary()` to skip saving if the target file already exists, preventing unnecessary overwrites.

### Logging Cleanup:
* [`MyGameMaker/MyGameEngine/Material.h`](diffhunk://#diff-8d6609c869214743497faa6b257acd6b9e55907657f9666c13e7a09f4d38a911L168-R168): Commented out a log message in the `Material` class that was deemed unnecessary, reducing log clutter.